### PR TITLE
PHP 5.4 compatibility

### DIFF
--- a/gdaldataset.cc
+++ b/gdaldataset.cc
@@ -336,7 +336,7 @@ PHP_METHOD(GDALDataset, MarkAsShared)
 // PHP stuff
 //
 
-function_entry gdaldataset_methods[] = {
+zend_function_entry gdaldataset_methods[] = {
   PHP_ME(GDALDataset, GetRasterXSize, NULL, ZEND_ACC_PUBLIC)
   PHP_ME(GDALDataset, GetRasterYSize, NULL, ZEND_ACC_PUBLIC)
   PHP_ME(GDALDataset, GetRasterCount, NULL, ZEND_ACC_PUBLIC)

--- a/gdaldataset.cc
+++ b/gdaldataset.cc
@@ -62,9 +62,13 @@ zend_object_value gdaldataset_create_handler(zend_class_entry *type TSRMLS_DC)
 
   ALLOC_HASHTABLE(obj->std.properties);
   zend_hash_init(obj->std.properties, 0, NULL, ZVAL_PTR_DTOR, 0);
+#if PHP_VERSION_ID < 50399
   zend_hash_copy(obj->std.properties, &type->default_properties,
                  (copy_ctor_func_t)zval_add_ref,
                  (void *)&tmp, sizeof(zval *));
+#else
+  object_properties_init(&obj->std, type);
+#endif
 
   retval.handle =
     zend_objects_store_put(obj, NULL,

--- a/gdaldriver.cc
+++ b/gdaldriver.cc
@@ -278,7 +278,7 @@ PHP_METHOD(GDALDriver, DefaultCopyFiles)
 // PHP stuff
 //
 
-function_entry gdaldriver_methods[] = {
+zend_function_entry gdaldriver_methods[] = {
   //-- parent class
   PHP_ME(GDALDriver, GetDescription, NULL, ZEND_ACC_PUBLIC)
   PHP_ME(GDALDriver, SetDescription, NULL, ZEND_ACC_PUBLIC)

--- a/gdaldriver.cc
+++ b/gdaldriver.cc
@@ -61,9 +61,13 @@ zend_object_value gdaldriver_create_handler(zend_class_entry *type TSRMLS_DC)
 
   ALLOC_HASHTABLE(obj->std.properties);
   zend_hash_init(obj->std.properties, 0, NULL, ZVAL_PTR_DTOR, 0);
+#if PHP_VERSION_ID < 50399
   zend_hash_copy(obj->std.properties, &type->default_properties,
                  (copy_ctor_func_t)zval_add_ref,
                  (void *)&tmp, sizeof(zval *));
+#else
+  object_properties_init(&obj->std, type);
+#endif
 
   retval.handle =
     zend_objects_store_put(obj, NULL,

--- a/gdaldrivermanager.cc
+++ b/gdaldrivermanager.cc
@@ -300,7 +300,7 @@ PHP_METHOD(GDALDriverManager, SetHome)
 // PHP stuff
 //
 
-function_entry gdaldrivermanager_methods[] = {
+zend_function_entry gdaldrivermanager_methods[] = {
   PHP_ME(GDALDriverManager, GetDriverCount, NULL, ZEND_ACC_PUBLIC)
   PHP_ME(GDALDriverManager, GetDriver, NULL, ZEND_ACC_PUBLIC)
   PHP_ME(GDALDriverManager, GetDriverByName, NULL, ZEND_ACC_PUBLIC)

--- a/gdaldrivermanager.cc
+++ b/gdaldrivermanager.cc
@@ -61,9 +61,13 @@ zend_object_value gdaldrivermanager_create_handler(zend_class_entry *type TSRMLS
 
   ALLOC_HASHTABLE(obj->std.properties);
   zend_hash_init(obj->std.properties, 0, NULL, ZVAL_PTR_DTOR, 0);
+#if PHP_VERSION_ID < 50399
   zend_hash_copy(obj->std.properties, &type->default_properties,
                  (copy_ctor_func_t)zval_add_ref,
                  (void *)&tmp, sizeof(zval *));
+#else
+  object_properties_init(&obj->std, type);
+#endif
 
   retval.handle =
     zend_objects_store_put(obj, NULL,

--- a/ogrcoordtransform.cc
+++ b/ogrcoordtransform.cc
@@ -322,7 +322,7 @@ PHP_METHOD(OGRCoordinateTransformation, TransformEx)
 ZEND_BEGIN_ARG_INFO(arginfo_transform_methods, 1)
 ZEND_END_ARG_INFO();
 
-function_entry ogrcoordtransform_methods[] = {
+zend_function_entry ogrcoordtransform_methods[] = {
   PHP_ME(OGRCoordinateTransformation, __construct, NULL, ZEND_ACC_PUBLIC)
   PHP_ME(OGRCoordinateTransformation, GetSourceCS, NULL, ZEND_ACC_PUBLIC)
   PHP_ME(OGRCoordinateTransformation, GetTargetCS, NULL, ZEND_ACC_PUBLIC)

--- a/ogrcoordtransform.cc
+++ b/ogrcoordtransform.cc
@@ -63,8 +63,12 @@ zend_object_value ogrcoordtransform_create_handler(zend_class_entry *type TSRMLS
 
   ALLOC_HASHTABLE(obj->std.properties);
   zend_hash_init(obj->std.properties, 0, NULL, ZVAL_PTR_DTOR, 0);
+#if PHP_VERSION_ID < 50399
   zend_hash_copy(obj->std.properties, &type->default_properties,
                  (copy_ctor_func_t)zval_add_ref, (void *)&tmp, sizeof(zval *));
+#else
+  object_properties_init(&obj->std, type);
+#endif
 
   retval.handle = zend_objects_store_put(obj, NULL,
                                          ogrcoordtransform_free_storage, NULL TSRMLS_CC);

--- a/ogrdatasource.cc
+++ b/ogrdatasource.cc
@@ -456,7 +456,7 @@ PHP_METHOD(OGRDataSource, DestroyDataSource)
 // PHP stuff
 //
 
-function_entry ogrdatasource_methods[] = {
+zend_function_entry ogrdatasource_methods[] = {
   PHP_ME(OGRDataSource, GetName, NULL, ZEND_ACC_PUBLIC)
   PHP_ME(OGRDataSource, GetLayerCount, NULL, ZEND_ACC_PUBLIC)
   PHP_ME(OGRDataSource, GetLayer, NULL, ZEND_ACC_PUBLIC)

--- a/ogrdatasource.cc
+++ b/ogrdatasource.cc
@@ -107,9 +107,13 @@ zend_object_value ogrdatasource_create_handler(zend_class_entry *type TSRMLS_DC)
 
   ALLOC_HASHTABLE(obj->std.properties);
   zend_hash_init(obj->std.properties, 0, NULL, ZVAL_PTR_DTOR, 0);
+#if PHP_VERSION_ID < 50399
   zend_hash_copy(obj->std.properties, &type->default_properties,
                  (copy_ctor_func_t)zval_add_ref,
                  (void *)&tmp, sizeof(zval *));
+#else
+  object_properties_init(&obj->std, type);
+#endif
 
   retval.handle =
     zend_objects_store_put(obj, NULL,

--- a/ogrenvelope.cc
+++ b/ogrenvelope.cc
@@ -56,8 +56,12 @@ zend_object_value ogrenvelope_create_handler(zend_class_entry *type TSRMLS_DC)
 
   ALLOC_HASHTABLE(obj->std.properties);
   zend_hash_init(obj->std.properties, 0, NULL, ZVAL_PTR_DTOR, 0);
+#if PHP_VERSION_ID < 50399
   zend_hash_copy(obj->std.properties, &type->default_properties,
                  (copy_ctor_func_t)zval_add_ref, (void *)&tmp, sizeof(zval *));
+#else
+  object_properties_init(&obj->std, type);
+#endif
 
   retval.handle = zend_objects_store_put(obj, NULL,
                                          ogrenvelope_free_storage, NULL TSRMLS_CC);

--- a/ogrenvelope.cc
+++ b/ogrenvelope.cc
@@ -294,7 +294,7 @@ PHP_METHOD(OGREnvelope, AsArray)
 // PHP stuff
 //
 
-function_entry ogrenvelope_methods[] = {
+zend_function_entry ogrenvelope_methods[] = {
   PHP_ME(OGREnvelope, IsInit, NULL, ZEND_ACC_PUBLIC)
   PHP_ME(OGREnvelope, Merge, NULL, ZEND_ACC_PUBLIC)
   PHP_ME(OGREnvelope, MergeCoords, NULL, ZEND_ACC_PUBLIC)

--- a/ogrexception.cc
+++ b/ogrexception.cc
@@ -6,7 +6,7 @@
 zend_class_entry *gdal_ogrexception_ce;
 zend_object_handlers ogrexception_object_handlers;
 
-function_entry ogrexception_methods[] = {
+zend_function_entry ogrexception_methods[] = {
   {NULL, NULL, NULL}
 };
 

--- a/ogrfeature.cc
+++ b/ogrfeature.cc
@@ -401,7 +401,7 @@ PHP_METHOD(OGRFeature, DestroyFeature)
 // PHP stuff
 //
 
-function_entry ogrfeature_methods[] = {
+zend_function_entry ogrfeature_methods[] = {
   PHP_ME(OGRFeature, GetDefnRef, NULL, ZEND_ACC_PUBLIC)
   // PHP_ME(OGRFeature, SetGeometryDirectly, NULL, ZEND_ACC_PUBLIC)
   // PHP_ME(OGRFeature, SetGeometry, NULL, ZEND_ACC_PUBLIC)

--- a/ogrfeature.cc
+++ b/ogrfeature.cc
@@ -60,8 +60,12 @@ zend_object_value ogrfeature_create_handler(zend_class_entry *type TSRMLS_DC)
 
   ALLOC_HASHTABLE(obj->std.properties);
   zend_hash_init(obj->std.properties, 0, NULL, ZVAL_PTR_DTOR, 0);
+#if PHP_VERSION_ID < 50399
   zend_hash_copy(obj->std.properties, &type->default_properties,
                  (copy_ctor_func_t)zval_add_ref, (void *)&tmp, sizeof(zval *));
+#else
+  object_properties_init(&obj->std, type);
+#endif
 
   retval.handle = zend_objects_store_put(obj, NULL,
                                          ogrfeature_free_storage, NULL TSRMLS_CC);

--- a/ogrfeaturedefn.cc
+++ b/ogrfeaturedefn.cc
@@ -304,7 +304,7 @@ PHP_METHOD(OGRFeatureDefn, Release)
 // PHP stuff
 //
 
-function_entry ogrfeaturedefn_methods[] = {
+zend_function_entry ogrfeaturedefn_methods[] = {
   PHP_ME(OGRFeatureDefn, GetName,               NULL, ZEND_ACC_PUBLIC)
   PHP_ME(OGRFeatureDefn, GetFieldCount,         NULL, ZEND_ACC_PUBLIC)
   PHP_ME(OGRFeatureDefn, GetFieldDefn,          NULL, ZEND_ACC_PUBLIC)

--- a/ogrfeaturedefn.cc
+++ b/ogrfeaturedefn.cc
@@ -57,8 +57,12 @@ zend_object_value ogrfeaturedefn_create_handler(zend_class_entry *type TSRMLS_DC
 
   ALLOC_HASHTABLE(obj->std.properties);
   zend_hash_init(obj->std.properties, 0, NULL, ZVAL_PTR_DTOR, 0);
+#if PHP_VERSION_ID < 50399
   zend_hash_copy(obj->std.properties, &type->default_properties,
                  (copy_ctor_func_t)zval_add_ref, (void *)&tmp, sizeof(zval *));
+#else
+      object_properties_init(&obj->std, type);
+#endif
 
   retval.handle = zend_objects_store_put(obj, NULL,
                                          ogrfeaturedefn_free_storage, NULL TSRMLS_CC);

--- a/ogrfielddefn.cc
+++ b/ogrfielddefn.cc
@@ -56,8 +56,12 @@ zend_object_value ogrfielddefn_create_handler(zend_class_entry *type TSRMLS_DC)
 
   ALLOC_HASHTABLE(obj->std.properties);
   zend_hash_init(obj->std.properties, 0, NULL, ZVAL_PTR_DTOR, 0);
+#if PHP_VERSION_ID < 50399
   zend_hash_copy(obj->std.properties, &type->default_properties,
                  (copy_ctor_func_t)zval_add_ref, (void *)&tmp, sizeof(zval *));
+#else
+      object_properties_init(&obj->std, type);
+#endif
 
   retval.handle = zend_objects_store_put(obj, NULL,
                                          ogrfielddefn_free_storage, NULL TSRMLS_CC);

--- a/ogrfielddefn.cc
+++ b/ogrfielddefn.cc
@@ -247,7 +247,7 @@ PHP_METHOD(OGRFieldDefn, SetPrecision)
 // PHP stuff
 //
 
-function_entry ogrfielddefn_methods[] = {
+zend_function_entry ogrfielddefn_methods[] = {
   PHP_ME(OGRFieldDefn, SetName,                 NULL, ZEND_ACC_PUBLIC)
   PHP_ME(OGRFieldDefn, GetNameRef,              NULL, ZEND_ACC_PUBLIC)
   PHP_ME(OGRFieldDefn, GetType,                 NULL, ZEND_ACC_PUBLIC)

--- a/ogrgeometry.cc
+++ b/ogrgeometry.cc
@@ -288,7 +288,7 @@ PHP_METHOD(OGRGeometry, GetSpatialReference)
 
 
 
-function_entry ogrgeometry_methods[] = {
+zend_function_entry ogrgeometry_methods[] = {
   PHP_ME(OGRGeometry, IsValid, NULL, ZEND_ACC_PUBLIC)
   PHP_ME(OGRGeometry, ExportToWkt, NULL, ZEND_ACC_PUBLIC)
   PHP_ME(OGRGeometry, ExportToWkb, NULL, ZEND_ACC_PUBLIC)

--- a/ogrgeometry.cc
+++ b/ogrgeometry.cc
@@ -33,8 +33,12 @@ zend_object_value ogrgeometry_create_handler(zend_class_entry *type TSRMLS_DC)
 
   ALLOC_HASHTABLE(obj->std.properties);
   zend_hash_init(obj->std.properties, 0, NULL, ZVAL_PTR_DTOR, 0);
+#if PHP_VERSION_ID < 50399
   zend_hash_copy(obj->std.properties, &type->default_properties,
                  (copy_ctor_func_t)zval_add_ref, (void *)&tmp, sizeof(zval *));
+#else
+  object_properties_init(&obj->std, type);
+#endif
 
   retval.handle = zend_objects_store_put(obj, NULL,
                                          ogrgeometry_free_storage, NULL TSRMLS_CC);

--- a/ogrgeometry.cc
+++ b/ogrgeometry.cc
@@ -192,14 +192,22 @@ PHP_METHOD(OGRGeometry, ExportToGML)
   obj = (php_ogrgeometry_object *) zend_object_store_get_object(getThis() TSRMLS_CC);
   geometry = obj->geometry;
 
+#if ! ((GDAL_VERSION_MAJOR <= 1) && (GDAL_VERSION_MINOR < 8))
   if (gmlOptionsLen != 0) {
     papszOptions = CSLAddString(papszOptions, gmlOptions);
   } 
 
   gmlText = geometry->exportToGML(papszOptions);
+#else
+  gmlText = geometry->exportToGML();
+#endif
+
+#if ! ((GDAL_VERSION_MAJOR <= 1) && (GDAL_VERSION_MINOR < 8))
   if (papszOptions) {
     CSLDestroy(papszOptions);
   }
+#endif
+
   if (gmlText == NULL) {
     php_gdal_ogr_throw("Failed to convert geometry to GML");
     RETURN_EMPTY_STRING();

--- a/ogrlayer.cc
+++ b/ogrlayer.cc
@@ -69,8 +69,12 @@ zend_object_value ogrlayer_create_handler(zend_class_entry *type TSRMLS_DC)
 
   ALLOC_HASHTABLE(obj->std.properties);
   zend_hash_init(obj->std.properties, 0, NULL, ZVAL_PTR_DTOR, 0);
+#if PHP_VERSION_ID < 50399
   zend_hash_copy(obj->std.properties, &type->default_properties,
                  (copy_ctor_func_t)zval_add_ref, (void *)&tmp, sizeof(zval *));
+#else
+  object_properties_init(&obj->std, type);
+#endif
 
   retval.handle = zend_objects_store_put(obj, NULL,
                                          ogrlayer_free_storage, NULL TSRMLS_CC);

--- a/ogrlayer.cc
+++ b/ogrlayer.cc
@@ -633,7 +633,7 @@ PHP_METHOD(OGRLayer, GetFeaturesRead)
 // PHP stuff
 //
 
-function_entry ogrlayer_methods[] = {
+zend_function_entry ogrlayer_methods[] = {
   // PHP_ME(OGRLayer, GetSpatialFilter,            NULL, ZEND_ACC_PUBLIC)
   // PHP_ME(OGRLayer, SetSpatialFilter,            NULL, ZEND_ACC_PUBLIC)
   PHP_ME(OGRLayer, SetSpatialFilterRect,        NULL, ZEND_ACC_PUBLIC)

--- a/ogrsfdriver.cc
+++ b/ogrsfdriver.cc
@@ -56,8 +56,12 @@ zend_object_value ogrsfdriver_create_handler(zend_class_entry *type TSRMLS_DC)
 
   ALLOC_HASHTABLE(obj->std.properties);
   zend_hash_init(obj->std.properties, 0, NULL, ZVAL_PTR_DTOR, 0);
+#if PHP_VERSION_ID < 50399
   zend_hash_copy(obj->std.properties, &type->default_properties,
                  (copy_ctor_func_t)zval_add_ref, (void *)&tmp, sizeof(zval *));
+#else
+  object_properties_init(&obj->std, type);
+#endif
 
   retval.handle = zend_objects_store_put(obj, NULL,
                                          ogrsfdriver_free_storage, NULL TSRMLS_CC);

--- a/ogrsfdriver.cc
+++ b/ogrsfdriver.cc
@@ -116,7 +116,7 @@ PHP_METHOD(OGRSFDriver, TestCapability)
 // PHP stuff
 //
 
-function_entry ogrsfdriver_methods[] = {
+zend_function_entry ogrsfdriver_methods[] = {
   PHP_ME(OGRSFDriver, GetName, NULL, ZEND_ACC_PUBLIC)
   //PHP_ME(OGRSFDriver, Open, NULL, ZEND_ACC_PUBLIC)
   PHP_ME(OGRSFDriver, TestCapability, NULL, ZEND_ACC_PUBLIC)

--- a/ogrsfdriverregistrar.cc
+++ b/ogrsfdriverregistrar.cc
@@ -63,8 +63,13 @@ zend_object_value ogrsfdriverregistrar_create_handler(zend_class_entry *type TSR
 
   ALLOC_HASHTABLE(obj->std.properties);
   zend_hash_init(obj->std.properties, 0, NULL, ZVAL_PTR_DTOR, 0);
+
+#if PHP_VERSION_ID < 50399
   zend_hash_copy(obj->std.properties, &type->default_properties,
                  (copy_ctor_func_t)zval_add_ref, (void *)&tmp, sizeof(zval *));
+#else
+  object_properties_init(&obj->std, type);
+#endif
 
   retval.handle = zend_objects_store_put(obj, NULL,
                                          ogrsfdriverregistrar_free_storage, NULL TSRMLS_CC);

--- a/ogrsfdriverregistrar.cc
+++ b/ogrsfdriverregistrar.cc
@@ -310,7 +310,7 @@ PHP_METHOD(OGRSFDriverRegistrar, Open)
 // PHP stuff
 //
 
-function_entry ogrsfdriverregistrar_methods[] = {
+zend_function_entry ogrsfdriverregistrar_methods[] = {
   // despite the API web page, there is no DeregisterDriver()
   PHP_ME(OGRSFDriverRegistrar,  RegisterDriver,  NULL, ZEND_ACC_PUBLIC)
   PHP_ME(OGRSFDriverRegistrar,  GetDriverCount,  NULL, ZEND_ACC_PUBLIC)

--- a/ogrspatialreference.cc
+++ b/ogrspatialreference.cc
@@ -56,8 +56,12 @@ zend_object_value ogrspatialreference_create_handler(zend_class_entry *type TSRM
 
   ALLOC_HASHTABLE(obj->std.properties);
   zend_hash_init(obj->std.properties, 0, NULL, ZVAL_PTR_DTOR, 0);
+#if PHP_VERSION_ID < 50399
   zend_hash_copy(obj->std.properties, &type->default_properties,
                  (copy_ctor_func_t)zval_add_ref, (void *)&tmp, sizeof(zval *));
+#else
+  object_properties_init(&obj->std, type);
+#endif
 
   retval.handle = zend_objects_store_put(obj, NULL,
                                          ogrspatialreference_free_storage, NULL TSRMLS_CC);

--- a/ogrspatialreference.cc
+++ b/ogrspatialreference.cc
@@ -754,7 +754,7 @@ PHP_METHOD(OGRSpatialReference, GetAuthorityName)
 // PHP stuff
 //
 
-function_entry ogrspatialreference_methods[] = {
+zend_function_entry ogrspatialreference_methods[] = {
   PHP_ME(OGRSpatialReference, __construct, NULL, ZEND_ACC_PUBLIC)
   PHP_ME(OGRSpatialReference, Reference, NULL, ZEND_ACC_PUBLIC)
   PHP_ME(OGRSpatialReference, Dereference, NULL, ZEND_ACC_PUBLIC)

--- a/php_gdal.cc
+++ b/php_gdal.cc
@@ -374,7 +374,7 @@ PHP_MINFO_FUNCTION(gdal)
   DISPLAY_INI_ENTRIES();
 }
 
-static function_entry gdal_functions[] = {
+static zend_function_entry gdal_functions[] = {
   PHP_FE(cplerrorreset, NULL)
   PHP_FE(cplgetlasterrorno, NULL)
   PHP_FE(cplgetlasterrortype, NULL)

--- a/tests/ogrgeometry.phpt
+++ b/tests/ogrgeometry.phpt
@@ -46,7 +46,6 @@ echo "OGRGeometry->ExportToJson: " . json_encode(json_decode($geom->ExportToJson
 
 echo "OGRGeometry->ExportToKML: " . $geom->ExportToKML() . "\n";
 echo "OGRGeometry->ExportToGML: " . $geom->ExportToGML() . "\n";
-echo "OGRGeometry->ExportToGML (GML3): " . $geom->ExportToGML("FORMAT=GML3") . "\n";
 echo "OGRGeometry->IsEmpty: " . bool2string($geom->IsEmpty()) . "\n";
 ?>
 --EXPECT--
@@ -62,5 +61,4 @@ OGRException on illegal byteorder caught.
 OGRGeometry->ExportToJson: {"type":"Point","coordinates":[-28,35]}
 OGRGeometry->ExportToKML: <Point><coordinates>-28,35</coordinates></Point>
 OGRGeometry->ExportToGML: <gml:Point><gml:coordinates>-28,35</gml:coordinates></gml:Point>
-OGRGeometry->ExportToGML (GML3): <gml:Point><gml:pos>-28 35</gml:pos></gml:Point>
 OGRGeometry->IsEmpty: FALSE


### PR DESCRIPTION
PHP 5.4 deprecated some parts of its internal API like `function_entry`
and initializing new zend objects with `object_properties_init` instead of the old `zend_hash_copy`.

This pull request addresses these issues and allows compiling php5-gdal with PHP 5.4.
